### PR TITLE
Removes references to NativeMethodsMixin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 import React, { Component } from 'react';
 import {
-    NativeMethodsMixin,
     ReactNativeViewAttributes,
     NativeModules,
     StyleSheet,
@@ -21,8 +20,6 @@ function extend(el, map) {
     return el;
 }
 var TableView = React.createClass({
-    mixins: [NativeMethodsMixin],
-
     propTypes: {
         onPress: React.PropTypes.func,
         onAccessoryPress: React.PropTypes.func,


### PR DESCRIPTION
NativeMethodMixin produces error on rn 0.33 and above. Removed it since it isn't being used.